### PR TITLE
refactor core

### DIFF
--- a/login-module/src/core.js
+++ b/login-module/src/core.js
@@ -68,7 +68,7 @@ export default class GraphAcademyCore {
 	}
 
 	validateRequest() {
-		if (!this.authResult.accessToken) {
+		if (!this.authResult || !this.authResult.accessToken) {
 			throw new Error(`accessToken not available. Cannot make a request to API`);
 		}
 	}

--- a/login-module/src/core.js
+++ b/login-module/src/core.js
@@ -3,8 +3,8 @@ import Quiz from './quiz'
 import Enrollment from './enrollment'
 import Certificate from './certificate'
 
-function validateOptions(options, requiredOptions, defaultOptions) {
-	const opts = { ...defaultOptions, ...options }
+function validateOptions(options, requiredOptions) {
+	const opts = { ...options }
 	const hasRequiredOptions = requiredOptions.every(item => opts[item])
 	if (!hasRequiredOptions) {
 		throw new Error(`required option missing - one of ${requiredOptions.join(', ')}`)
@@ -12,51 +12,13 @@ function validateOptions(options, requiredOptions, defaultOptions) {
 	return opts
 }
 
-class GraphAcademyServices {
-	constructor(options = {}) {
-		const requiredOptions = ['trainingClassName', 'enrollmentUrl', 'authResult']
-		this.options = validateOptions(options, requiredOptions, {})
-		const { stage, trainingClassName, authResult } = this.options
-		this.authResult = authResult
-		this.certificate = new Certificate(trainingClassName, stage)
-		this.enrollment = new Enrollment(trainingClassName, stage)
-		this.quiz = new Quiz(trainingClassName, stage)
-	}
-
-	async enrollStudentInClass (firstName, lastName) {
-		return this.enrollment.enrollStudentInClass(firstName, lastName, this.getAccessToken())
-	}
-
-	async getEnrollmentForClass() {
-		return this.enrollment.getEnrollmentForClass(this.getAccessToken())
-	}
-
-	async getQuizStatus() {
-		return this.quiz.getQuizStatus(this.getAccessToken())
-	}
-
-	async getClassCertificate() {
-		return this.certificate.getClassCertificate(this.getAccessToken())
-	}
-
-	async postQuizStatus(passed, failed) {
-		return this.quiz.postQuizStatus(passed, failed, this.getAccessToken())
-	}
-
-	getAccessToken () {
-		return this.authResult.accessToken
-	}
-}
-
 export default class GraphAcademyCore {
 	constructor(options = {}) {
-		const requiredOptions = ['trainingClassName', 'enrollmentUrl']
+		const requiredOptions = ['trainingClassName', 'enrollmentUrl', 'authResult']
 		const defaultOptions = {
 			stage: 'prod',
-			trainingClassName: null,
-			enrollmentUrl: null,
 		}
-		this.options = validateOptions(options, requiredOptions, defaultOptions)
+		this.options = { ...defaultOptions, ...validateOptions(options, requiredOptions) }
 		this.webAuth = new WebAuth({
 			clientID: 'hoNo6B00ckfAoFVzPTqzgBIJHFHDnHYu',
 			domain: 'login.neo4j.com',
@@ -65,22 +27,50 @@ export default class GraphAcademyCore {
 			scope: 'read:account-info openid email profile user_metadata',
 			responseType: 'token id_token'
 		})
+		const { stage, trainingClassName } = this.options
+		this.certificate = new Certificate(trainingClassName, stage)
+		this.enrollment = new Enrollment(trainingClassName, stage)
+		this.quiz = new Quiz(trainingClassName, stage)
+
 	}
 
 	async login() {
-		const { options, webAuth } = this
-		return new Promise((resolve, _) => {
-			webAuth.checkSession({}, async (err, result) => {
-				if (err) {
-					return resolve([err, null])
-				}
-				if (result && result.accessToken) {
-					options.authResult = result
-					return resolve([null, new GraphAcademyServices(options)])
-				}
-				return resolve([new Error('Invalid authentication result'), result])
-			})
+		const { webAuth } = this
+		webAuth.checkSession({}, (err, result) => {
+			if (result) this.authResult = result;
+			return [err, result];
 		})
+	}
+
+	async enrollStudentInClass(firstName, lastName) {
+		this.validateRequest();
+		return this.enrollment.enrollStudentInClass(firstName, lastName, this.authResult.accessToken)
+	}
+
+	async getEnrollmentForClass() {
+		this.validateRequest();
+		return this.enrollment.getEnrollmentForClass(this.authResult.accessToken)
+	}
+
+	async getQuizStatus() {
+		this.validateRequest();
+		return this.quiz.getQuizStatus(this.authResult.accessToken)
+	}
+
+	async getClassCertificate() {
+		this.validateRequest();
+		return this.certificate.getClassCertificate(this.authResult.accessToken)
+	}
+
+	async postQuizStatus(passed, failed) {
+		this.validateRequest();
+		return this.quiz.postQuizStatus(passed, failed, this.authResult.accessToken)
+	}
+
+	validateRequest() {
+		if (!this.authResult.accessToken) {
+			throw new Error(`accessToken not available. Cannot make a request to API`);
+		}
 	}
 
 	logout() {


### PR DESCRIPTION
I'd suggest we keep the core library a little more simple. I saw 4 different classes and was a little confusing to understand at first.

I turned them into 2 classes - `GraphAcademyPage` that deals with initializing and DOM related functions. The other is `GraphAcademyCore` that deals with auth0+API calls (that require accessToken)